### PR TITLE
fix: no fallback

### DIFF
--- a/pages/asset/[slug].tsx
+++ b/pages/asset/[slug].tsx
@@ -33,7 +33,7 @@ export async function getStaticPaths() {
         paths: tokens.map((asset) => ({
             params: { slug: asset.slug },
         })),
-        fallback: true,
+        fallback: false,
     };
 }
 


### PR DESCRIPTION
Fixes build issue
As long as you always re-build with Strapi Webhook (which we set up during call), this is good